### PR TITLE
dirty fix "unexpected end of JSON input"

### DIFF
--- a/influxdb-zabbix.go
+++ b/influxdb-zabbix.go
@@ -74,7 +74,7 @@ func (p *Param) gatherData() error {
 	// read registry
 	if err := registry.Read(&config, &mapTables); err != nil {
 		fmt.Println(err)
-		return err
+		//return err
 	}
 
 	// set times


### PR DESCRIPTION
Previously when we receive "unexpected end of JSON input" influxdb-zabbix stop processing problem table and require app restart.
This hack fix this problem and table still parsing without restart