### PR TITLE
Update mysql.go renamed groups to hstgrp due to zabbix change

### DIFF
--- a/input/mysql.go
+++ b/input/mysql.go
@@ -51,7 +51,7 @@ FROM trends tre
 INNER JOIN items ite on ite.itemid = tre.itemid
 INNER JOIN hosts hos on hos.hostid = ite.hostid
 INNER JOIN hosts_groups hg on hg.hostid = hos.hostid
-INNER JOIN groups grp on grp.groupid = hg.groupid
+INNER JOIN hstgrp grp on grp.groupid = hg.groupid
 WHERE grp.internal=0
    AND tre.clock > ##STARTDATE##
    AND tre.clock <= ##ENDDATE##;
@@ -91,7 +91,7 @@ FROM trends tre
 INNER JOIN items ite on ite.itemid = tre.itemid
 INNER JOIN hosts hos on hos.hostid = ite.hostid
 INNER JOIN hosts_groups hg on hg.hostid = hos.hostid
-INNER JOIN groups grp on grp.groupid = hg.groupid
+INNER JOIN hstgrp grp on grp.groupid = hg.groupid
 WHERE grp.internal=0
    AND tre.clock > ##STARTDATE##
    AND tre.clock <= ##ENDDATE##;
@@ -129,7 +129,7 @@ FROM history his
 INNER JOIN items ite on ite.itemid = his.itemid
 INNER JOIN hosts hos on hos.hostid = ite.hostid
 INNER JOIN hosts_groups hg on hg.hostid = hos.hostid
-INNER JOIN groups grp on grp.groupid = hg.groupid
+INNER JOIN hstgrp grp on grp.groupid = hg.groupid
 WHERE grp.internal=0
    AND his.clock > ##STARTDATE##
    AND his.clock <= ##ENDDATE##;
@@ -167,7 +167,7 @@ FROM history_uint his
 INNER JOIN items ite on ite.itemid = his.itemid
 INNER JOIN hosts hos on hos.hostid = ite.hostid
 INNER JOIN hosts_groups hg on hg.hostid = hos.hostid
-INNER JOIN groups grp on grp.groupid = hg.groupid
+INNER JOIN hstgrp grp on grp.groupid = hg.groupid
 WHERE grp.internal=0
    AND his.clock > ##STARTDATE##
    AND his.clock <= ##ENDDATE##;


### PR DESCRIPTION
Zabbix has changed the name of table groups to hstgrp due to key reservations in mysql 8

https://www.zabbix.com/forum/zabbix-help/374145-is-table-groups-on-mysql-missing-after-update-3-2-11-to-4-0-4
